### PR TITLE
Add H2 config and Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# ServicioLibros
+
+Aplicación Spring Boot para gestionar préstamos de libros en una institución educativa. Permite registrar usuarios y libros, solicitar y devolver préstamos, calcular multas por retraso y consultar reportes.
+
+## Configuración
+
+La aplicación utiliza una base de datos en memoria H2 y se configura automáticamente al iniciar. Para ejecutar el proyecto desde la línea de comandos:
+
+```bash
+./mvnw spring-boot:run
+```
+
+Al levantar la aplicación estarán disponibles:
+
+- Consola H2: [http://localhost:8080/h2-console](http://localhost:8080/h2-console)
+- Documentación Swagger: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+
+## Ejemplo de uso con Swagger
+
+1. **Crear un usuario**
+   - Endpoint: `POST /api/usuarios`
+   - Cuerpo de ejemplo:
+     ```json
+     { "nombre": "Juan", "rol": "ESTUDIANTE" }
+     ```
+
+2. **Registrar un libro**
+   - Endpoint: `POST /api/libros`
+   - Cuerpo de ejemplo:
+     ```json
+     { "titulo": "La Odisea", "autor": "Homero" }
+     ```
+
+3. **Solicitar un préstamo**
+   - Endpoint: `POST /api/prestamos/solicitar`
+   - Cuerpo de ejemplo:
+     ```json
+     { "usuarioId": "1", "libroId": "1", "fechaEntrega": "2024-08-25" }
+     ```
+
+4. **Devolver un libro**
+   - Endpoint: `POST /api/prestamos/devolver/{prestamoId}`
+
+5. **Consultar reportes**
+   - Libros: `GET /api/reportes/libros`
+   - Libros prestados: `GET /api/reportes/libros-prestados`
+   - Usuarios: `GET /api/reportes/usuarios`
+   - Multas: `GET /api/reportes/multas`
+
+Los endpoints anteriores pueden probarse directamente desde la interfaz Swagger.

--- a/src/main/java/org/sci/serviciolibros/config/OpenApiConfig.java
+++ b/src/main/java/org/sci/serviciolibros/config/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package org.sci.serviciolibros.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Servicio de Libros",
+        version = "1.0",
+        description = "API para gestionar préstamos de libros"
+    )
+)
+@Configuration
+public class OpenApiConfig {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=ServicioLibros
+spring.datasource.url=jdbc:h2:mem:servicio_libros_db
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
## Summary
- configure H2 database and enable console
- add OpenAPI configuration
- document how to use the API with Swagger

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9e9081708332bf8cbc2da6540a5a