### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+target
+.mvn/wrapper/maven-wrapper.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use Maven to build the application
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY .mvn .mvn
+COPY src src
+COPY mvnw mvnw
+RUN ./mvnw -B package -DskipTests
+
+# Use a minimal JRE to run the app
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/ServicioLibros-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ Al levantar la aplicación estarán disponibles:
    - Multas: `GET /api/reportes/multas`
 
 Los endpoints anteriores pueden probarse directamente desde la interfaz Swagger.
+
+## Docker
+
+Para construir y ejecutar la aplicación en un contenedor Docker:
+
+```bash
+docker build -t serviciolibros .
+docker run -p 8080:8080 serviciolibros
+```
+
+Al levantar el contenedor, la interfaz Swagger estará disponible en [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html).


### PR DESCRIPTION
## Summary
- provide Dockerfile for multi-stage build and run
- ignore build artifacts via `.dockerignore`
- document Docker usage in README

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_684d88dde9e483328510977b6a61dba3